### PR TITLE
Revamp workflows

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Build image
         run: docker buildx build -t ${{ github.event.repository.name }} --file ./Dockerfile . --platform linux/amd64 --load
       - name: Test image
-        run: docker run -i ${{ github.event.repository.name }}
+        run: echo "git clone https://github.com/launchbynttdata/tf-azurerm-module_primitive-resource_group.git; cd tf-azurerm-module_primitive-resource_group; make configure" | docker run ${{ github.event.repository.name }} /usr/bin/bash
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Push image

--- a/.github/workflows/cleanup-branch-image.yaml
+++ b/.github/workflows/cleanup-branch-image.yaml
@@ -1,0 +1,32 @@
+name: Cleanup Branch Image
+on: delete
+
+permissions:
+  packages: write
+
+jobs:
+  delete:
+    outputs:
+      output1: ${{ steps.DetermineTagName.outputs.container_tag }}
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - id: determine_tag_name
+        name: Determine Tag Name
+        run: |
+          echo "Clean up for branch ${{ github.event.ref }}"
+          container_tag=$(echo "${{ github.event.ref }}" | sed -e 's,refs/[head|tag]*s/,,g' | sed -e 's,/,-,g' | sed -e 's/!/-breaking/g' ) # This strips the git ref prefix from the version and replaces any remaining / characters with a -.
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && container_tag=$(echo $container_tag | sed -e 's/^v//') # This strips the "v" prefix from the tag name.
+          echo "Will remove container tagged with '$container_tag'"
+          echo "container_tag=$container_tag" >> $GITHUB_OUTPUT
+      - name: Delete Tag
+        uses: chipkent/action-cleanup-package@v1.0.1
+        with:
+          package-name: ${{ github.event.repository.name }}
+          tag: ${{ steps.determine_tag_name.outputs.container_tag }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cleanup Untagged
+        uses: dylanratcliffe/delete-untagged-containers@v1.2.3
+        with:
+          package_name: ${{ github.event.repository.name }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/increment-tagged-version.yaml
+++ b/.github/workflows/increment-tagged-version.yaml
@@ -1,11 +1,11 @@
+name: Increment Tagged Version
+
 on:
   pull_request:
     types:
       - closed
     branches:
       - main
-
-name: increment-tagged-version
 
 permissions:
   contents: write

--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Build image
         run: docker buildx build -t ${{ github.event.repository.name }} --file ./Dockerfile . --platform linux/amd64 --load
       - name: Test image
-        run: docker run -i ${{ github.event.repository.name }}
+        run: echo "git clone https://github.com/launchbynttdata/tf-azurerm-module_primitive-resource_group.git; cd tf-azurerm-module_primitive-resource_group; make configure" | docker run ${{ github.event.repository.name }} /usr/bin/bash
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Push image tags

--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -1,9 +1,11 @@
-name: Build Container
+name: Release Container
 
 on:
-  push:
-    branches-ignore:
-      - "main"
+  workflow_run:
+    workflows:
+        - Increment Tagged Version
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -26,16 +28,19 @@ jobs:
         run: docker run -i ${{ github.event.repository.name }}
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Push image
+      - name: Push image tags
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]') # This changes all uppercase characters to lowercase.
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,refs/[head|tag]*s/,,g' | sed -e 's,/,-,g' | sed -e 's/!/-breaking/g' ) # This strips the git ref prefix from the version and replaces any remaining / characters with a -.
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//') # This strips the "v" prefix from the tag name.
+          SEMVER_TAG=$(git tag --points-at HEAD | tail -n 1)
+          LATEST_TAG=latest
           echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-          docker tag ${{ github.event.repository.name }} $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          echo SEMVER_TAG=$SEMVER_TAG
+          echo LATEST_TAG=$LATEST_TAG
+          docker tag ${{ github.event.repository.name }} $IMAGE_ID:$SEMVER_TAG
+          docker push $IMAGE_ID:$SEMVER_TAG
+          docker tag ${{ github.event.repository.name }} $IMAGE_ID:$LATEST_TAG
+          docker push $IMAGE_ID:$LATEST_TAG
       - name: Cleanup Untagged
         uses: dylanratcliffe/delete-untagged-containers@v1.2.3
         with:

--- a/.github/workflows/validate-branch-name.yaml
+++ b/.github/workflows/validate-branch-name.yaml
@@ -2,7 +2,7 @@ on:
   pull_request:
     branches: [ "main" ]
 
-name: validate-branch-name
+name: Validate Branch Name
 
 permissions:
   contents: read


### PR DESCRIPTION
Revamps all our container-related workflows:

- build-container.yaml
  - Now only builds containers for non-main branches
  - Registry name is driven off the repository name directly
  - Git branch name is translated when generating the container tag; `refs/heads/` and `refs/tags/` is dropped, further `/` characters are replaced by `-` characters, and the `!` character to denote a breaking change is replaced with `-breaking`. Given branch names of `fix/foo` and `feature!/bar`, the container tags would reflect `fix-foo` and `feature-breaking-bar`, respectively.
  - Images present in the registry that do not have a tag are cleaned up.
- cleanup-branch-image.yaml
  - New workflow to remove images tagged with the branch once the branch is deleted. This is normally accomplished by closing the PR (the repository is set to auto-remove branches after PR close), but if someone submits a branch and later deletes it through the CLI or UI, this is handled as well.
  - Images present in the registry that do nto have a tag are cleaned up.
- increment-tagged-version.yaml
  - Reformat workflow name to Proper Case.
- release-container.yaml
  - New workflow that closely follows the build-container.yaml workflow used to build containers for a branch.
  - This workflow is triggered only after the increment-tagged-version workflow runs to ensure that the updated semver tags are present in the repository.
  - The container will be tagged and pushed twice -- once for the semantic versioning tag, and a second time to update the `latest` tag that follows the HEAD of `main`. This ensures that semantic versions stay consistent and `latest` can be used if version stability is not required.
  - Images present in the registry that do not have a tag are cleaned up.
- validate-branch-name.yaml
  - Reformat workflow name to Proper Case.
  
My plan is to make sure this is all working well prior to PRing similar changes to the -aws and -azure variants of the build agent.